### PR TITLE
Add evaluation script and basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ Say **"run python"** followed by a description of the code you want to generate 
 ## Finished:
 - Removed hard-coded API keys from the source
 
+## Evaluation
+
+Run the benchmark script to exercise the assistant without launching any
+applications:
+
+```bash
+python evaluate_vos_ai.py
+```
+
+Results are written to `benchmark_results.json`.
+
 ## License
 
 This project is released under the [MIT License](LICENSE).

--- a/evaluate_vos_ai.py
+++ b/evaluate_vos_ai.py
@@ -1,0 +1,66 @@
+import json
+import time
+import vos_ai
+
+# Prompts for conversational evaluation
+CHAT_PROMPTS = [
+    "Tell me the time.",
+    "Who is the president of the United States?"
+]
+
+# Commands to test application opening logic
+APP_COMMANDS = [
+    "open chrome",
+    "search google for Python testing"
+]
+
+def evaluate_chat(prompts):
+    results = []
+    for prompt in prompts:
+        start = time.time()
+        try:
+            response = vos_ai.chat(prompt)
+        except Exception as e:
+            response = f"ERROR: {e}"
+        elapsed = time.time() - start
+        results.append({"prompt": prompt, "response": response, "elapsed": elapsed})
+    return results
+
+def evaluate_open_application(commands):
+    results = []
+    executed = []
+
+    def dummy_system(cmd):
+        executed.append(cmd)
+
+    def dummy_open(url):
+        executed.append(url)
+
+    orig_system = vos_ai.os.system
+    orig_webopen = vos_ai.webbrowser.open
+    vos_ai.os.system = dummy_system
+    vos_ai.webbrowser.open = dummy_open
+
+    try:
+        for command in commands:
+            executed.clear()
+            matched = vos_ai.open_application(command)
+            results.append({"command": command, "executed": executed[:], "matched": matched})
+    finally:
+        vos_ai.os.system = orig_system
+        vos_ai.webbrowser.open = orig_webopen
+
+    return results
+
+
+def main():
+    chat_results = evaluate_chat(CHAT_PROMPTS)
+    app_results = evaluate_open_application(APP_COMMANDS)
+    report = {"chat": chat_results, "application": app_results}
+    with open("benchmark_results.json", "w") as f:
+        json.dump(report, f, indent=2)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_vos_ai.py
+++ b/tests/test_vos_ai.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest import mock
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import vos_ai
+
+class TestOpenApplication(unittest.TestCase):
+    def test_known_command(self):
+        with mock.patch('vos_ai.os.system') as mock_system:
+            result = vos_ai.open_application('open chrome')
+            self.assertTrue(result)
+            mock_system.assert_called_once()
+
+    def test_search_google(self):
+        with mock.patch('vos_ai.webbrowser.open') as mock_open:
+            result = vos_ai.open_application('search google for unit testing')
+            self.assertTrue(result)
+            mock_open.assert_called_once()
+
+    def test_unknown_command(self):
+        with mock.patch('vos_ai.os.system') as mock_system:
+            result = vos_ai.open_application('do something unknown')
+            self.assertFalse(result)
+            mock_system.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `evaluate_vos_ai.py` to benchmark chat and command handling
- add unit tests for `open_application`
- document how to run the benchmark in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `python evaluate_vos_ai.py` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6853597f80388332b6d17e7ee6d9578f