### PR TITLE
Add audio-aware benchmarking and handle missing deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Say **"run python"** followed by a description of the code you want to generate 
 ## Finished:
 - Removed hard-coded API keys from the source
 
+## Evaluation
+
+Run the benchmark script to exercise the assistant without launching any
+applications. It can optionally evaluate recorded audio commands if
+OpenAI is available:
+
+```bash
+python evaluate_vos_ai.py
+```
+
+Results are written to `benchmark_results.json`. To test with audio samples,
+add paths to WAV files in the `AUDIO_FILES` list inside
+`evaluate_vos_ai.py`.
+
 ## License
 
 This project is released under the [MIT License](LICENSE).

--- a/evaluate_vos_ai.py
+++ b/evaluate_vos_ai.py
@@ -1,0 +1,123 @@
+import json
+import os
+import time
+
+import vos_ai
+
+# Prompts for conversational evaluation
+CHAT_PROMPTS = [
+    "Tell me the time.",
+    "Who is the president of the United States?"
+]
+
+# Commands to test application opening logic
+APP_COMMANDS = [
+    "open chrome",
+    "search google for Python testing"
+]
+
+# Optional list of audio files containing spoken commands for evaluation.
+AUDIO_FILES = []  # e.g. ["samples/open_chrome.wav"]
+
+def evaluate_chat(prompts):
+    results = []
+    if vos_ai.OpenAI is None:
+        for prompt in prompts:
+            results.append({"prompt": prompt, "response": "SKIPPED", "elapsed": 0})
+        return results
+    for prompt in prompts:
+        start = time.time()
+        try:
+            response = vos_ai.chat(prompt)
+        except Exception as e:
+            response = f"ERROR: {e}"
+        elapsed = time.time() - start
+        results.append({"prompt": prompt, "response": response, "elapsed": elapsed})
+    return results
+
+def evaluate_open_application(commands):
+    results = []
+    executed = []
+
+    def dummy_system(cmd):
+        executed.append(cmd)
+
+    def dummy_open(url):
+        executed.append(url)
+
+    orig_system = vos_ai.os.system
+    orig_webopen = vos_ai.webbrowser.open
+    vos_ai.os.system = dummy_system
+    vos_ai.webbrowser.open = dummy_open
+
+    try:
+        for command in commands:
+            executed.clear()
+            matched = vos_ai.open_application(command)
+            results.append({"command": command, "executed": executed[:], "matched": matched})
+    finally:
+        vos_ai.os.system = orig_system
+        vos_ai.webbrowser.open = orig_webopen
+
+    return results
+
+
+def evaluate_audio_commands(files):
+    """Transcribe audio files and run them through open_application."""
+    results = []
+    if vos_ai.OpenAI is None:
+        # Cannot transcribe without OpenAI support
+        return results
+
+    for path in files:
+        start = time.time()
+        try:
+            text = vos_ai.transcribe(path)
+            executed = []
+
+            def dummy_system(cmd):
+                executed.append(cmd)
+
+            def dummy_open(url):
+                executed.append(url)
+
+            orig_system = vos_ai.os.system
+            orig_open = vos_ai.webbrowser.open
+            vos_ai.os.system = dummy_system
+            vos_ai.webbrowser.open = dummy_open
+            try:
+                matched = vos_ai.open_application(text)
+            finally:
+                vos_ai.os.system = orig_system
+                vos_ai.webbrowser.open = orig_open
+            elapsed = time.time() - start
+            results.append({
+                "file": path,
+                "transcription": text,
+                "executed": executed,
+                "matched": matched,
+                "elapsed": elapsed,
+            })
+        except Exception as e:
+            results.append({"file": path, "error": str(e)})
+
+    return results
+
+
+def main():
+    chat_results = evaluate_chat(CHAT_PROMPTS)
+    app_results = evaluate_open_application(APP_COMMANDS)
+    audio_results = evaluate_audio_commands(AUDIO_FILES)
+
+    report = {
+        "chat": chat_results,
+        "application": app_results,
+        "audio": audio_results,
+    }
+    with open("benchmark_results.json", "w") as f:
+        json.dump(report, f, indent=2)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_vos_ai.py
+++ b/tests/test_vos_ai.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest import mock
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import vos_ai
+
+class TestOpenApplication(unittest.TestCase):
+    def test_known_command(self):
+        with mock.patch('vos_ai.os.system') as mock_system:
+            result = vos_ai.open_application('open chrome')
+            self.assertTrue(result)
+            mock_system.assert_called_once()
+
+    def test_search_google(self):
+        with mock.patch('vos_ai.webbrowser.open') as mock_open:
+            result = vos_ai.open_application('search google for unit testing')
+            self.assertTrue(result)
+            mock_open.assert_called_once()
+
+    def test_unknown_command(self):
+        with mock.patch('vos_ai.os.system') as mock_system:
+            result = vos_ai.open_application('do something unknown')
+            self.assertFalse(result)
+            mock_system.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `vos_ai` to import without heavy dependencies
- support audio command evaluation in `evaluate_vos_ai.py`
- document how to use audio evaluation in README

## Testing
- `pytest -q`
- `python evaluate_vos_ai.py`

------
https://chatgpt.com/codex/tasks/task_e_6853597f80388332b6d17e7ee6d9578f