### PR TITLE
Implement cross‑platform commands and clean up TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Say **"run python"** followed by a description of the code you want to generate 
 
 ## TODO
 
-- Cross-platform support for Linux and macOS
 - User-friendly GUI interface
+## Finished:
+- Cross-platform support for Linux and macOS
 - More built-in voice commands
 - Better error handling for speech recognition
-## Finished:
 - Removed hard-coded API keys from the source
 
 ## Evaluation

--- a/tests/test_vos_ai.py
+++ b/tests/test_vos_ai.py
@@ -7,19 +7,22 @@ import vos_ai
 
 class TestOpenApplication(unittest.TestCase):
     def test_known_command(self):
-        with mock.patch('vos_ai.os.system') as mock_system:
+        with mock.patch('vos_ai.os.system') as mock_system, \
+             mock.patch('vos_ai.synthesis'):
             result = vos_ai.open_application('open chrome')
             self.assertTrue(result)
             mock_system.assert_called_once()
 
     def test_search_google(self):
-        with mock.patch('vos_ai.webbrowser.open') as mock_open:
+        with mock.patch('vos_ai.webbrowser.open') as mock_open, \
+             mock.patch('vos_ai.synthesis'):
             result = vos_ai.open_application('search google for unit testing')
             self.assertTrue(result)
             mock_open.assert_called_once()
 
     def test_unknown_command(self):
-        with mock.patch('vos_ai.os.system') as mock_system:
+        with mock.patch('vos_ai.os.system') as mock_system, \
+             mock.patch('vos_ai.synthesis'):
             result = vos_ai.open_application('do something unknown')
             self.assertFalse(result)
             mock_system.assert_not_called()


### PR DESCRIPTION
## Summary
- allow optional imports so the project can be imported without heavy deps
- add basic error handling in `transcribe`
- rewrite `open_application` with per-platform command mapping and extra commands
- adjust unit tests for the new function behaviour
- update README TODO list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853660fdf508332be264d5d964b1f56